### PR TITLE
WD API KEYでSECRETを使う対応

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -2,7 +2,7 @@
   "watson": {
     "discovery": {
       "version": "2019-04-30",
-      "apikey": "RGrONJi28o6u0DHKGm15KebDxuTdR0oAP3svKqzP5DJy",
+      "apikey": "",
       "serviceUrl": "https://api.eu-gb.discovery.watson.cloud.ibm.com/instances/20f86910-fc02-4b7b-9faa-9e49666ceb72",
       "environmentId": "383f0953-ddd2-49dc-ac85-06d0f86be50b",
       "collectionId": "83d8d434-0761-4892-ab75-885c19092c9a"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,6 +21,12 @@ spec:
           ports:
             - name: http-listener
               containerPort: 8000
+          env:
+            - name: WD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: wd-api-key 
+                  key: WD_API_KEY
           # livenessProbe:
           #   httpGet:
           #     path: /

--- a/tools/call-discovery.js
+++ b/tools/call-discovery.js
@@ -3,9 +3,12 @@ const {IamAuthenticator} = require('ibm-watson/auth');
 const config = require('config');
 
 const discovery = new DiscoveryV1({
+  
+
   version: config.get('watson.discovery.version'),
   authenticator: new IamAuthenticator({
-    apikey: config.get('watson.discovery.apikey'),
+//    apikey: config.get('watson.discovery.apikey'),
+    apikey: process.env.WD_API_KEY,
   }),
   serviceUrl: config.get('watson.discovery.serviceUrl'),
 });


### PR DESCRIPTION
表題の件の対応をしてみたので、もし時間に余裕があれば動作確認してみてください。
secretとなるWDのAPI KEYは`wd-api-key`というname でWebコンソールから登録済です。(↓のURLでアクセスできるかどうかはちょっとわからない)
~~https://console-openshift-console.itzroks-120000mck6-ot8q5v-6ccd7f378ae819553d37d5f2ee142bd6-0000.jp-tok.containers.appdomain.cloud/k8s/ns/team-taurus-backend/secrets/wd-api-key~~
↑古い環境でした、のでsecret作り直します。↓作りました 🙏 
https://console-openshift-console.itzroks-120000mck6-xyyb1x-6ccd7f378ae819553d37d5f2ee142bd6-0000.jp-tok.containers.appdomain.cloud/k8s/ns/team-taurus-backend/secrets/wd-api-key/

Webコンソールから登録したsecretが期待通りの値として環境変数経由でアクセスできるか確認できればなのですが、こちらで無駄にプロジェクトやパイプラインを作るとまたpvcの課題など発生するかもしれないので、時間に余裕があれば動作確認よろしくおねがいします 🙇 